### PR TITLE
Updated eks_cluster to take bastion instance and disk as parameter. …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/
+.idea

--- a/cluster-bootstrap/cdk.json
+++ b/cluster-bootstrap/cdk.json
@@ -2,6 +2,8 @@
 { 
     "app": "python eks_cluster.py",
     "context": {
+        "account": "",
+        "region": "",
         "create_new_cluster_admin_role": "True",
         "existing_admin_role_arn": "arn:aws:iam::123456789123:role/RoleName",
         "create_new_vpc": "True",
@@ -33,6 +35,8 @@
         "deploy_calico_np": "True",
         "deploy_ssm_agent": "True",
         "deploy_bastion": "True",
+        "basiton_node_type": "t3.large",
+        "basiton_disk_size": 20,
         "deploy_client_vpn": "False",
         "vpn_client_certificate_arn": "arn:aws:acm:ap-southeast-2:123456789123:certificate/XXX",
         "vpn_server_certificate_arn": "arn:aws:acm:ap-southeast-2:123456789123:certificate/XXX",


### PR DESCRIPTION
Updated eks_cluster to take bastion instance and disk as parameter. Updated to take account and region from context.   if blank will use environment account and region  Added venv and .idea to gitignore. 

*Issue #, if available:*

*Description of changes:*
 eks_cluster.py updated to take 
- bastion instance type  and disk as parameter.
- Updated to take account and region from context.   if blank will use environment account and region  

.gitignore
Added venv and .idea to gitignore. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
